### PR TITLE
fix NameError in case of SSL

### DIFF
--- a/lib/two_captcha.rb
+++ b/lib/two_captcha.rb
@@ -1,6 +1,7 @@
 require 'base64'
 require 'json'
 require 'net/http'
+require 'openssl'
 
 # The module TwoCaptcha contains all the code for the two_captcha gem.
 # It acts as a safely namespace that isolates logic from TwoCaptcha from any


### PR DESCRIPTION
There is a "uninitialized constant OpenSSL" exception in TwoCaptcha::HTTP#open_url
